### PR TITLE
Fix command syntax bug in get_hidden_service_descriptor() 

### DIFF
--- a/stem/control.py
+++ b/stem/control.py
@@ -1962,7 +1962,7 @@ class Controller(BaseController):
       request = 'HSFETCH %s' % address
 
       if servers:
-        request += ' '.join(['SERVER=%s' % s for s in servers])
+        request += ' ' + ' '.join(['SERVER=%s' % s for s in servers])
 
       response = self.msg(request)
       stem.response.convert('SINGLELINE', response)


### PR DESCRIPTION
The `get_hidden_service_descriptor` function takes an onion
address and a list of hidden service descriptors to fetch the
hidden service descriptor from.

This commit fixes a bug where a space was missing between the onion
address and the first SERVER= argument.